### PR TITLE
Fix bug where previous alignments are always loaded for shank 1

### DIFF
--- a/atlaselectrophysiology/ephys_atlas_gui.py
+++ b/atlaselectrophysiology/ephys_atlas_gui.py
@@ -1699,7 +1699,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if upload == QtWidgets.QMessageBox.Yes:
             upload_channels = self.loaddata.upload_data(self.xyz_channels)
             self.loaddata.update_alignments(self.features[self.idx], self.track[self.idx])
-            self.prev_alignments = self.loaddata.get_previous_alignments()
+            self.prev_alignments = self.loaddata.get_previous_alignments(self.current_shank_idx)
             self.populate_lists(self.prev_alignments, self.align_list, self.align_combobox)
             self.loaddata.get_starting_alignment(0)
             resolved = self.loaddata.update_qc()
@@ -1738,7 +1738,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if upload == QtWidgets.QMessageBox.Yes:
             self.loaddata.upload_data(self.features[self.idx], self.track[self.idx],
                                       self.xyz_channels)
-            self.prev_alignments = self.loaddata.get_previous_alignments()
+            self.prev_alignments = self.loaddata.get_previous_alignments(self.current_shank_idx)
             self.populate_lists(self.prev_alignments, self.align_list, self.align_combobox)
             self.loaddata.get_starting_alignment(0)
             QtWidgets.QMessageBox.information(self, 'Status', "Channels locations saved")


### PR DESCRIPTION
Very simple bugfix. There was a small issue where if I went to save alignments for a second (or third, etc.) time, it would always get saved to shank 1, even for shanks 2-4 in the 4-shank case. I fixed this so now it loads previous alignments for the correct shank. 