### PR TITLE
Fix FlatIron 401 on histology stack download (redirect strips auth)

### DIFF
--- a/atlaselectrophysiology/load_histology.py
+++ b/atlaselectrophysiology/load_histology.py
@@ -20,6 +20,7 @@ def download_histology_data(subject, lab):
         FLAT_IRON_HIST_REL_PATH = Path('histology', lab_temp, subject,
                                        'downsampledStacks_25', 'sample2ARA')
         baseurl = (par.HTTP_DATA_SERVER + '/' + '/'.join(FLAT_IRON_HIST_REL_PATH.parts))
+        baseurl = (par.HTTP_DATA_SERVER + '/' + '/'.join(FLAT_IRON_HIST_REL_PATH.parts) + '/')
         r = requests.get(baseurl, auth=(par.HTTP_DATA_SERVER_LOGIN, par.HTTP_DATA_SERVER_PWD))
         r.raise_for_status()
     except Exception as err:
@@ -29,6 +30,7 @@ def download_histology_data(subject, lab):
             FLAT_IRON_HIST_REL_PATH = Path('histology', lab_temp, subject_rem,
                                            'downsampledStacks_25', 'sample2ARA')
             baseurl = (par.HTTP_DATA_SERVER + '/' + '/'.join(FLAT_IRON_HIST_REL_PATH.parts))
+            baseurl = (par.HTTP_DATA_SERVER + '/' + '/'.join(FLAT_IRON_HIST_REL_PATH.parts) + '/')
             r = requests.get(baseurl, auth=(par.HTTP_DATA_SERVER_LOGIN, par.HTTP_DATA_SERVER_PWD))
             r.raise_for_status()
         except Exception as err:
@@ -38,6 +40,7 @@ def download_histology_data(subject, lab):
                     FLAT_IRON_HIST_REL_PATH = Path('histology', lab_temp, subject,
                                                    'downsampledStacks_25', 'sample2ARA')
                     baseurl = (par.HTTP_DATA_SERVER + '/' + '/'.join(FLAT_IRON_HIST_REL_PATH.parts))
+                    baseurl = (par.HTTP_DATA_SERVER + '/' + '/'.join(FLAT_IRON_HIST_REL_PATH.parts) + '/')
                     r = requests.get(baseurl, auth=(par.HTTP_DATA_SERVER_LOGIN, par.HTTP_DATA_SERVER_PWD))
                     r.raise_for_status()
                 except Exception as err:
@@ -63,6 +66,7 @@ def download_histology_data(subject, lab):
         path_to_image = Path(CACHE_DIR, file)
         if not path_to_image.exists():
             url = (baseurl + '/' + file)
+            url = (baseurl + file)
             http_download_file(url, target_dir=CACHE_DIR,
                                username=par.HTTP_DATA_SERVER_LOGIN,
                                password=par.HTTP_DATA_SERVER_PWD)


### PR DESCRIPTION
download_histology_data() omits a trailing slash on FlatIron URLs, triggering a 301 to a slash-terminated path via an http (non-TLS) hop. requests strips the Authorization header on https->http scheme downgrade, causing a 401 even with correct credentials. Fix: construct URLs with the trailing slash to avoid the redirect.